### PR TITLE
Issue #2 Implemented the MD5 hash algorithm check

### DIFF
--- a/s3auth-hosts/src/test/java/com/s3auth/hosts/HtpasswdTest.java
+++ b/s3auth-hosts/src/test/java/com/s3auth/hosts/HtpasswdTest.java
@@ -79,11 +79,9 @@ public final class HtpasswdTest {
     /**
      * Htpasswd can manage apache hashes, with MD5 algorithm.
      * @throws Exception If there is some problem inside
-     * @todo #1 This is not implemented yet
      * @link ftp://ftp.arlut.utexas.edu/pub/java_hashes/MD5Crypt.java
      */
     @Test
-    @org.junit.Ignore
     public void understandsApacheNativeHashValues() throws Exception {
         MatcherAssert.assertThat(
             new Htpasswd(


### PR DESCRIPTION
<a href="https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/digest/Md5Crypt.html">Md5Crypt</a> is based on the same algorithm by Poul Henning-Kemp as the code at ftp://ftp.arlut.utexas.edu/pub/java_hashes/MD5Crypt.java . Since the project already imports Commons-Codec I thought it would be helpful if we used it here instead.
