### PR TITLE
Issue #88 Exposed Age HTTP Header

### DIFF
--- a/s3auth-relay/src/main/java/com/s3auth/relay/HttpThread.java
+++ b/s3auth-relay/src/main/java/com/s3auth/relay/HttpThread.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
@@ -130,6 +131,14 @@ final class HttpThread {
                     );
                 final Resource resource =
                     this.resource(this.host(request), request);
+                response = response.withHeader(
+                    org.apache.http.HttpHeaders.AGE,
+                    String.valueOf(
+                        TimeUnit.MILLISECONDS.toSeconds(
+                            System.currentTimeMillis() - start
+                        )
+                    )
+                );
                 if (resource.lastModified() != null) {
                     response = response.withHeader(
                         HttpHeaders.LAST_MODIFIED,


### PR DESCRIPTION
Spec: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6

Based on my interpretation of the HTTP 1.1 specification, Age does not actually pertain to the age of the actual object (say, the way "Last-Modified" does) but its age as it resides in some intermediate cache.

However, `ObjectMetaData` exposes neither an `Age` that we can pass along nor a `Date` which indicates the time that the resource has been generated. Thus my presumption is every resource is returned from S3 "on-demand". This explains the calculation of age as the time from when the request was first received by S3Auth to the time that the resource was retrieved (and consequently, the response being generated). Thus, the Age being returned represents the "freshness" of S3Auth's generated response, and indicates to any intermediate proxy caches whether they should refresh their copies or not.

I hope that makes sense. Maybe this is incorrect, let me know what you think.
