### PR TITLE
Issue #72 Htpasswd and Resource plain texts now use UTF-8

### DIFF
--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/Htpasswd.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/Htpasswd.java
@@ -48,6 +48,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.Crypt;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.codec.digest.Md5Crypt;
+import org.apache.commons.io.Charsets;
 
 /**
  * Htpasswd file abstraction.
@@ -150,7 +151,7 @@ final class Htpasswd {
             );
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             res.writeTo(baos);
-            content = baos.toString().trim();
+            content = baos.toString(Charsets.UTF_8.name()).trim();
         } catch (final IOException ex) {
             Logger.warn(
                 this,

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/Resource.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/Resource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -118,7 +119,7 @@ public interface Resource {
         @Override
         public long writeTo(@NotNull final OutputStream stream)
             throws IOException {
-            IOUtils.write(this.text, stream);
+            IOUtils.write(this.text, stream, Charsets.UTF_8);
             return this.text.getBytes().length;
         }
         @Override

--- a/s3auth-hosts/src/mock/java/com/s3auth/hosts/ResourceMocker.java
+++ b/s3auth-hosts/src/mock/java/com/s3auth/hosts/ResourceMocker.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -70,17 +71,18 @@ public final class ResourceMocker {
         try {
             Mockito.doAnswer(
                 new Answer<Void>() {
+                    @Override
                     public Void answer(final InvocationOnMock invocation)
                         throws Exception {
                         final OutputStream output = OutputStream.class.cast(
                             invocation.getArguments()[0]
                         );
-                        IOUtils.write(content, output);
+                        IOUtils.write(content, output, Charsets.UTF_8);
                         return null;
                     }
                 }
             ).when(this.resource).writeTo(Mockito.any(OutputStream.class));
-        } catch (java.io.IOException ex) {
+        } catch (final java.io.IOException ex) {
             throw new IllegalStateException(ex);
         }
         return this;
@@ -93,7 +95,7 @@ public final class ResourceMocker {
      * @throws IOException If fails
      */
     public static String toString(final Resource res) throws IOException {
-        return new String(ResourceMocker.toByteArray(res));
+        return new String(ResourceMocker.toByteArray(res), Charsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
The issue here was that the character `\u0433` is not available in the `Windows-1252` charset. What I did is that I changed `Htpasswd` and `Resource` so that they'll process plaintext in `UTF-8`. What do you think?
