### PR TITLE
Issue #144 Cached AmazonS3Client and AmazonCloudWatchClient instances

### DIFF
--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
@@ -30,6 +30,7 @@
 package com.s3auth.hosts;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -70,11 +71,11 @@ final class DefaultBucket implements Bucket {
     @NotNull
     @Cacheable(lifetime = Tv.TEN, unit = TimeUnit.MINUTES)
     public AmazonS3 client() {
-        final ClientConfiguration config = new ClientConfiguration();
-        config.setSocketTimeout(0);
         final AmazonS3 client = new AmazonS3Client(
             new BasicAWSCredentials(this.domain.key(), this.domain.secret()),
-            config
+            new ClientConfiguration()
+                .withSocketTimeout(0)
+                .withProtocol(Protocol.HTTP)
         );
         client.setEndpoint(
             String.format("%s.amazonaws.com", this.domain.region())

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultHost.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultHost.java
@@ -31,6 +31,8 @@ package com.s3auth.hosts;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
@@ -90,6 +92,7 @@ final class DefaultHost implements Host {
                     Manifests.read("S3Auth-AwsCloudWatchKey"),
                     Manifests.read("S3Auth-AwsCloudWatchSecret")
                 ),
+                new ClientConfiguration().withProtocol(Protocol.HTTP),
                 Executors.newFixedThreadPool(Tv.FIFTY)
             );
         }


### PR DESCRIPTION
For `AmazonS3Client`, the instances are cached per domain, while for `AmazonCloudWatchClient`, there is one holder of a cacheable instance for the entire application.

Previously, a new `AmazonS3Client` would be created when `DefaultBucket.client()` was called, and a new `AmazonCloudWatchClient` was created when `DefaultHost` was constructed. Creating new instances of these objects caused a SSL handshake to occur, which caused a disproportionately large amount of CPU utilization.

I also removed the `config.setProtocol(Protocol.HTTP)` calls under the presumption that they were put in as a workaround to the excessive `SSLContext.getDefault()` CPU usage.
