### PR TITLE
#183 Refactored Resource to use immutable Array header

### DIFF
--- a/s3auth-hosts/pom.xml
+++ b/s3auth-hosts/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>jcabi-aspects</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-immutable</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
I couldn't reproduce the NPE described in #183, but it appears to have been coming from the `Arrays.asList()` call. It was refactored accordingly.
