### PR TITLE
#225 added Manifest.mf to s3auth-relay-*.jar

### DIFF
--- a/s3auth-relay/pom.xml
+++ b/s3auth-relay/pom.xml
@@ -189,6 +189,7 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
                         <archive>
+                            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
                             <manifestEntries>
                                 <Main-Class>com.s3auth.relay.Main</Main-Class>
                             </manifestEntries>


### PR DESCRIPTION
The original `IllegalArgumentException` was because of using wrong manifest file in `s3auth-relay-*.jar`. I added it and no exception is thrown.
