### PR TITLE
#90: DefaultDynamo: Would be nice to migrate to jcabi-dynamo

### DIFF
--- a/s3auth-hosts/pom.xml
+++ b/s3auth-hosts/pom.xml
@@ -193,6 +193,11 @@
             <artifactId>h2</artifactId>
             <version>1.3.176</version>
         </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-dynamo</artifactId>
+            <version>0.18.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultDynamo.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultDynamo.java
@@ -29,22 +29,19 @@
  */
 package com.s3auth.hosts;
 
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
-import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
-import com.amazonaws.services.dynamodbv2.model.ScanRequest;
-import com.amazonaws.services.dynamodbv2.model.ScanResult;
-import com.google.common.collect.ImmutableMap;
 import com.jcabi.aspects.Cacheable;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.aspects.Tv;
+import com.jcabi.dynamo.Credentials;
+import com.jcabi.dynamo.Item;
+import com.jcabi.dynamo.Region;
+import com.jcabi.dynamo.retry.ReRegion;
 import com.jcabi.manifests.Manifests;
 import com.jcabi.urn.URN;
-import java.util.Map;
+import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +62,7 @@ import lombok.ToString;
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(of = { "client", "table" })
+@EqualsAndHashCode(of = { "region", "table" })
 @Loggable(Loggable.INFO)
 final class DefaultDynamo implements Dynamo {
 
@@ -107,7 +104,7 @@ final class DefaultDynamo implements Dynamo {
     /**
      * Client.
      */
-    private final transient Dynamo.Client client;
+    private final transient Region region;
 
     /**
      * Table name.
@@ -118,37 +115,34 @@ final class DefaultDynamo implements Dynamo {
      * Public ctor.
      */
     DefaultDynamo() {
-        this(
-            new Dynamo.Client() {
-                @Override
-                public AmazonDynamoDB get() {
-                    final AmazonDynamoDB aws = new AmazonDynamoDBClient(
-                        new BasicAWSCredentials(
-                            Manifests.read("S3Auth-AwsDynamoKey"),
-                            Manifests.read("S3Auth-AwsDynamoSecret")
-                        )
-                    );
-                    // @checkstyle MultipleStringLiterals (1 line)
-                    if (Manifests.exists("S3Auth-AwsDynamoEntryPoint")) {
-                        aws.setEndpoint(
-                            Manifests.read("S3Auth-AwsDynamoEntryPoint")
-                        );
-                    }
-                    return aws;
-                }
-            },
-            Manifests.read("S3Auth-AwsDynamoTable")
+        final Credentials creds = new Credentials.Simple(
+            Manifests.read("S3Auth-AwsDynamoKey"),
+            Manifests.read("S3Auth-AwsDynamoSecret")
         );
+        // @checkstyle MultipleStringLiterals (1 line)
+        if (Manifests.exists("S3Auth-AwsDynamoEntryPoint")) {
+            this.region = new ReRegion(
+                new Region.Simple(
+                    new Credentials.Direct(
+                        creds,
+                        Manifests.read("S3Auth-AwsDynamoEntryPoint")
+                    )
+                )
+            );
+        } else {
+            this.region = new ReRegion(new Region.Simple(creds));
+        }
+        this.table = Manifests.read("S3Auth-AwsDynamoTable");
     }
 
     /**
      * Ctor for unit tests.
-     * @param clnt The client to Dynamo DB
+     * @param rgn The jcabi-dynamo Region
      * @param tbl Table name
      */
-    DefaultDynamo(@NotNull final Dynamo.Client clnt,
+    DefaultDynamo(@NotNull final Region rgn,
         @NotNull final String tbl) {
-        this.client = clnt;
+        this.region = rgn;
         this.table = tbl;
     }
 
@@ -161,20 +155,18 @@ final class DefaultDynamo implements Dynamo {
     @NotNull
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     @Cacheable(lifetime = Tv.FIVE, unit = TimeUnit.MINUTES)
-    public ConcurrentMap<URN, Domains> load() {
+    public ConcurrentMap<URN, Domains> load() throws IOException {
         final ConcurrentMap<URN, Domains> domains =
             new ConcurrentHashMap<URN, Domains>(0);
-        final AmazonDynamoDB amazon = this.client.get();
-        final ScanResult result = amazon.scan(new ScanRequest(this.table));
-        for (final Map<String, AttributeValue> item : result.getItems()) {
+        for (final Item item : this.region.table(this.table).frame()) {
             final String syslog;
-            if (item.containsKey(DefaultDynamo.SYSLOG)) {
+            if (item.has(DefaultDynamo.SYSLOG)) {
                 syslog = item.get(DefaultDynamo.SYSLOG).getS();
             } else {
                 syslog = "syslog.s3auth.com:514";
             }
             final String bucket;
-            if (item.containsKey(DefaultDynamo.BUCKET)) {
+            if (item.has(DefaultDynamo.BUCKET)) {
                 bucket = item.get(DefaultDynamo.BUCKET).getS();
             } else {
                 bucket = item.get(DefaultDynamo.NAME).getS();
@@ -192,14 +184,13 @@ final class DefaultDynamo implements Dynamo {
                 )
             );
         }
-        amazon.shutdown();
         return domains;
     }
 
     @Override
     @Cacheable.FlushBefore
     public boolean add(@NotNull final URN user,
-        @NotNull final Domain domain) {
+        @NotNull final Domain domain) throws IOException {
         final ConcurrentMap<String, AttributeValue> attrs =
             new ConcurrentHashMap<String, AttributeValue>(0);
         attrs.put(DefaultDynamo.USER, new AttributeValue(user.toString()));
@@ -209,25 +200,19 @@ final class DefaultDynamo implements Dynamo {
         attrs.put(DefaultDynamo.REGION, new AttributeValue(domain.region()));
         attrs.put(DefaultDynamo.SYSLOG, new AttributeValue(domain.syslog()));
         attrs.put(DefaultDynamo.BUCKET, new AttributeValue(domain.bucket()));
-        final AmazonDynamoDB amazon = this.client.get();
-        amazon.putItem(new PutItemRequest(this.table, attrs));
-        amazon.shutdown();
+        this.region.table(this.table).put(attrs);
         return true;
     }
 
     @Override
     @Cacheable.FlushBefore
     public boolean remove(@NotNull final Domain domain) {
-        final AmazonDynamoDB amazon = this.client.get();
-        amazon.deleteItem(
-            new DeleteItemRequest(
-                this.table,
-                new ImmutableMap.Builder<String, AttributeValue>()
-                    .put(DefaultDynamo.NAME, new AttributeValue(domain.name()))
-                    .build()
-            )
-        );
-        amazon.shutdown();
+        final Iterator<Item> items = this.region.table(this.table).frame()
+            .where(DefaultDynamo.NAME, domain.name())
+            .iterator();
+        while (items.hasNext()) {
+            items.remove();
+        }
         return true;
     }
 

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultDynamo.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultDynamo.java
@@ -58,7 +58,6 @@ import lombok.ToString;
  * @version $Id$
  * @since 0.0.1
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
- * @todo #1 Would be nice to migrate to jcabi-dynamo
  */
 @Immutable
 @ToString


### PR DESCRIPTION
 - added dependency to jcabi-dynamo 0.18.1
 - DefaultDynamo
  - use jcabi-dynamo instead of Amazon Dynamo API
  - no longer use Client, instead use Region from jcabi-dynamo
 - DefaultDynamoTest
  - use Mock Region instead of Mock AmazonDynamoDB class
  - added puzzle for getting H2Data backend to work with special characters ( see [jcabi-dynamo issue 7](https://github.com/jcabi/jcabi-dynamo/issues/7) )