### PR TITLE
(#348) Removed unnecessary @Timeable from SmartHost.fetch

### DIFF
--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/SmartHost.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/SmartHost.java
@@ -31,13 +31,10 @@ package com.s3auth.hosts;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.aspects.Timeable;
-import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
@@ -97,7 +94,6 @@ final class SmartHost implements Host {
 
     @Override
     @Loggable(value = Loggable.DEBUG, ignore = IOException.class)
-    @Timeable(limit = Tv.FIVE, unit = TimeUnit.SECONDS)
     public Resource fetch(@NotNull final URI uri, @NotNull final Range range,
         @NotNull final Version version) throws IOException {
         final Resource resource;


### PR DESCRIPTION
This PR:
* solves #348 
* Removes unnecessary `@Timeable` from `SmartHost.fetch`

@yegor256 missed this `@Timeable` [here](https://github.com/yegor256/s3auth/issues/348#issuecomment-300687314). According to stacktraces [1](https://gist.github.com/nikita-leonov/87eac248a3a2de13da76402757a1e030) and [2](https://gist.github.com/lukesaunders/a04e0de7eeabe1bd13417f3ce9ccecbb), `SmartHost` is being decorated by `FastHost`, so the longer timeout configured in `FastHost` would not have taken effect with the much shorter one in `SmartHost`.