### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - MAVEN_OPTS="-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF-8"
     - JAVA_OPTS="-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF-8"
 install:
-  - travis_retry sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
+  - sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
   - gem install pdd -v 0.20.5
 script:
   - pdd --file=/dev/null


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
