### PR TITLE
Map legacy region strings to AWS SDK v2 (closes #577)

### DIFF
--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
@@ -54,36 +54,6 @@ final class DefaultBucket implements Bucket {
             .build();
     }
 
-    /**
-     * Translate a legacy S3 region/endpoint string into a SDK v2 {@link Region}.
-     * Old s3auth records carry values like {@code s3}, {@code s3-eu-west-1},
-     * {@code s3-website-us-east-1} or {@code s3.amazonaws.com}, none of which
-     * the v2 SDK understands. This method strips the legacy prefixes and
-     * suffixes and returns the underlying region id.
-     * @return Region for the AWS SDK
-     */
-    private Region awsRegion() {
-        String raw = this.domain.region().trim();
-        if (raw.endsWith(".amazonaws.com")) {
-            raw = raw.substring(0, raw.length() - ".amazonaws.com".length());
-        }
-        final int idx = raw.indexOf("s3");
-        if (idx > 0) {
-            raw = raw.substring(idx);
-        }
-        final String id;
-        if ("s3".equals(raw) || "s3-external-1".equals(raw)) {
-            id = "us-east-1";
-        } else if (raw.startsWith("s3-website-")) {
-            id = raw.substring("s3-website-".length());
-        } else if (raw.startsWith("s3-")) {
-            id = raw.substring("s3-".length());
-        } else {
-            id = raw;
-        }
-        return Region.of(id);
-    }
-
     @Override
     public String toString() {
         return this.domain.toString();
@@ -133,6 +103,36 @@ final class DefaultBucket implements Bucket {
     @Override
     public String syslog() {
         return this.domain.syslog();
+    }
+
+    /**
+     * Translate a legacy S3 region/endpoint string into a SDK v2 {@link Region}.
+     * Old s3auth records carry values like {@code s3}, {@code s3-eu-west-1},
+     * {@code s3-website-us-east-1} or {@code s3.amazonaws.com}, none of which
+     * the v2 SDK understands. This method strips the legacy prefixes and
+     * suffixes and returns the underlying region id.
+     * @return Region for the AWS SDK
+     */
+    private Region awsRegion() {
+        String raw = this.domain.region().trim();
+        if (raw.endsWith(".amazonaws.com")) {
+            raw = raw.substring(0, raw.length() - ".amazonaws.com".length());
+        }
+        final int idx = raw.indexOf("s3");
+        if (idx > 0) {
+            raw = raw.substring(idx);
+        }
+        final String id;
+        if ("s3".equals(raw) || "s3-external-1".equals(raw)) {
+            id = "us-east-1";
+        } else if (raw.startsWith("s3-website-")) {
+            id = raw.substring("s3-website-".length());
+        } else if (raw.startsWith("s3-")) {
+            id = raw.substring("s3-".length());
+        } else {
+            id = raw;
+        }
+        return Region.of(id);
     }
 
 }

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DefaultBucket.java
@@ -42,7 +42,7 @@ final class DefaultBucket implements Bucket {
     @Cacheable(lifetime = 10, unit = TimeUnit.MINUTES)
     public S3Client client() {
         return S3Client.builder()
-            .region(Region.of(this.domain.region()))
+            .region(this.awsRegion())
             .credentialsProvider(
                 StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(
@@ -52,6 +52,36 @@ final class DefaultBucket implements Bucket {
                 )
             )
             .build();
+    }
+
+    /**
+     * Translate a legacy S3 region/endpoint string into a SDK v2 {@link Region}.
+     * Old s3auth records carry values like {@code s3}, {@code s3-eu-west-1},
+     * {@code s3-website-us-east-1} or {@code s3.amazonaws.com}, none of which
+     * the v2 SDK understands. This method strips the legacy prefixes and
+     * suffixes and returns the underlying region id.
+     * @return Region for the AWS SDK
+     */
+    private Region awsRegion() {
+        String raw = this.domain.region().trim();
+        if (raw.endsWith(".amazonaws.com")) {
+            raw = raw.substring(0, raw.length() - ".amazonaws.com".length());
+        }
+        final int idx = raw.indexOf("s3");
+        if (idx > 0) {
+            raw = raw.substring(idx);
+        }
+        final String id;
+        if ("s3".equals(raw) || "s3-external-1".equals(raw)) {
+            id = "us-east-1";
+        } else if (raw.startsWith("s3-website-")) {
+            id = raw.substring("s3-website-".length());
+        } else if (raw.startsWith("s3-")) {
+            id = raw.substring("s3-".length());
+        } else {
+            id = raw;
+        }
+        return Region.of(id);
     }
 
     @Override

--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/H2DomainStatsData.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/H2DomainStatsData.java
@@ -101,7 +101,10 @@ final class H2DomainStatsData implements DomainStatsData {
      */
     public H2DomainStatsData init() throws IOException {
         try {
+            Class.forName("org.h2.Driver");
             this.session().sql(H2DomainStatsData.CREATE).execute().commit();
+        } catch (final ClassNotFoundException ex) {
+            throw new IOException("H2 JDBC driver not on classpath", ex);
         } catch (final SQLException ex) {
             throw new IOException(ex);
         }

--- a/s3auth-hosts/src/test/java/com/s3auth/hosts/DefaultBucketTest.java
+++ b/s3auth-hosts/src/test/java/com/s3auth/hosts/DefaultBucketTest.java
@@ -28,7 +28,7 @@ final class DefaultBucketTest {
     }
 
     @Test
-    void mapsLegacyS3RegionToUsEast() {
+    void mapsLegacyBareRegionToUsEast() {
         MatcherAssert.assertThat(
             "legacy 's3' must resolve to us-east-1",
             new DefaultBucket(
@@ -39,7 +39,7 @@ final class DefaultBucketTest {
     }
 
     @Test
-    void stripsS3PrefixFromRegionalEndpoint() {
+    void stripsLegacyPrefixFromRegionalEndpoint() {
         MatcherAssert.assertThat(
             "legacy 's3-eu-west-1' must drop the s3- prefix",
             new DefaultBucket(

--- a/s3auth-hosts/src/test/java/com/s3auth/hosts/DefaultBucketTest.java
+++ b/s3auth-hosts/src/test/java/com/s3auth/hosts/DefaultBucketTest.java
@@ -27,4 +27,82 @@ final class DefaultBucketTest {
         );
     }
 
+    @Test
+    void mapsLegacyS3RegionToUsEast() {
+        MatcherAssert.assertThat(
+            "legacy 's3' must resolve to us-east-1",
+            new DefaultBucket(
+                new DomainMocker().init().withRegion("s3").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("us-east-1")
+        );
+    }
+
+    @Test
+    void stripsS3PrefixFromRegionalEndpoint() {
+        MatcherAssert.assertThat(
+            "legacy 's3-eu-west-1' must drop the s3- prefix",
+            new DefaultBucket(
+                new DomainMocker().init().withRegion("s3-eu-west-1").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("eu-west-1")
+        );
+    }
+
+    @Test
+    void stripsWebsitePrefixFromRegion() {
+        MatcherAssert.assertThat(
+            "legacy 's3-website-us-east-1' must drop the s3-website- prefix",
+            new DefaultBucket(
+                new DomainMocker().init()
+                    .withRegion("s3-website-us-east-1").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("us-east-1")
+        );
+    }
+
+    @Test
+    void stripsAmazonawsSuffix() {
+        MatcherAssert.assertThat(
+            "'s3-eu-west-1.amazonaws.com' must drop the .amazonaws.com tail",
+            new DefaultBucket(
+                new DomainMocker().init()
+                    .withRegion("s3-eu-west-1.amazonaws.com").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("eu-west-1")
+        );
+    }
+
+    @Test
+    void mapsBareDomainEndpointToUsEast() {
+        MatcherAssert.assertThat(
+            "'s3.amazonaws.com' must collapse to us-east-1",
+            new DefaultBucket(
+                new DomainMocker().init().withRegion("s3.amazonaws.com").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("us-east-1")
+        );
+    }
+
+    @Test
+    void mapsExternalAliasToUsEast() {
+        MatcherAssert.assertThat(
+            "'s3-external-1' is the legacy alias for us-east-1",
+            new DefaultBucket(
+                new DomainMocker().init().withRegion("s3-external-1").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("us-east-1")
+        );
+    }
+
+    @Test
+    void preservesAlreadyValidRegionId() {
+        MatcherAssert.assertThat(
+            "valid SDK v2 region must pass through unchanged",
+            new DefaultBucket(
+                new DomainMocker().init().withRegion("eu-central-1").mock()
+            ).client().serviceClientConfiguration().region().id(),
+            Matchers.equalTo("eu-central-1")
+        );
+    }
 }

--- a/s3auth-relay/INSTALL.txt
+++ b/s3auth-relay/INSTALL.txt
@@ -40,7 +40,7 @@ Install Java & supplementary tools
 
     sudo apt-get update
     sudo apt-get -y upgrade
-    sudo apt-get -y install openjdk-8-jre-headless maven
+    sudo apt-get -y install openjdk-17-jre-headless maven
 
 Copy src/main/production/pom.xml to /home/ubuntu/pom.xml
 


### PR DESCRIPTION
## Summary
- `DefaultBucket.client()` now translates legacy v1 region strings (`s3`, `s3-eu-west-1`, `s3-website-us-east-1`, `s3-external-1`, `s3.amazonaws.com`, etc.) into valid AWS SDK v2 `Region` objects. Without this, every S3 fetch was returning `NoSuchBucket` for all 2031 registered domains.
- `H2DomainStatsData.init()` force-loads `org.h2.Driver` because the SPI auto-registration was not happening under the `exec-maven-plugin` classloader.
- `s3auth-relay/INSTALL.txt` bumped from `openjdk-8-jre-headless` to `openjdk-17-jre-headless` — `h2:2.4.240` is class file version 55.0 and refuses to load on JDK 8.

## Test plan
- [x] `DefaultBucketTest` adds 7 new cases covering each legacy pattern; all 8 tests pass.
- [x] Verified end-to-end on `relay.s3auth.com` after deploying the SNAPSHOT: anonymous → `401 Basic realm="maven.s3auth.com"`; `curl -u s3auth:s3auth http://maven.s3auth.com/` → `200 OK` returning the 14 KB bucket index.
- [ ] Reviewer to confirm Rultor's release path replaces the manually-deployed SNAPSHOT.

Closes #577