### PR TITLE
fix: return 404 for directory listing responses #324

### DIFF
--- a/s3auth-hosts/src/main/java/com/s3auth/hosts/DirectoryListing.java
+++ b/s3auth-hosts/src/main/java/com/s3auth/hosts/DirectoryListing.java
@@ -113,7 +113,7 @@ final class DirectoryListing implements Resource {
 
     @Override
     public int status() {
-        return HttpURLConnection.HTTP_OK;
+        return HttpURLConnection.HTTP_NOT_FOUND;
     }
 
     @Override


### PR DESCRIPTION
Maven and similar tooling probe the URL of a specific artifact and follow up with the response body. When the path resolves to a non-existent key inside the bucket, `DefaultHost` falls back to a `DirectoryListing`, which used to answer `200 OK`. Maven then treats the HTML listing as the artifact body and caches it, corrupting the local repository.

`DirectoryListing.status()` now returns `HttpURLConnection.HTTP_NOT_FOUND`. The HTML listing is still served as the body, so a browser visiting a folder URL still sees the usual page, while clients that branch on the status code correctly stop on a `404`. The change is a one-line constant swap inside the existing `status()` override.

Ran `mvn --batch-mode test` inside `s3auth-hosts/`: 69 tests pass, 3 skipped, 0 failures. The full `-Pqulice` build at the reactor root cannot run in this environment because `com.jcabi:jcabi-latex-maven-plugin:1.2.0` is unavailable from Maven Central and oss.sonatype.org, but CI on the PR will run the canonical build.

Closes #324
